### PR TITLE
Add telegraf config for swift.

### DIFF
--- a/Arista/ConfigFiles/telegraf-swift.conf
+++ b/Arista/ConfigFiles/telegraf-swift.conf
@@ -1,0 +1,262 @@
+# Telegraf Configuration
+#
+# Telegraf is entirely plugin driven. All metrics are gathered from the
+# declared inputs, and sent to the declared outputs.
+#
+# Plugins must be declared in here to be active.
+# To deactivate a plugin, comment out the name and any variables.
+#
+# Use 'telegraf -config telegraf.conf -test' to see what metrics a config
+# file would generate.
+#
+# Environment variables can be used anywhere in this config file, simply prepend
+# them with $. For strings the variable must be within quotes (ie, "$STR_VAR"),
+# for numbers and booleans they should be plain (ie, $INT_VAR, $BOOL_VAR)
+
+
+# Global tags can be specified here in key="value" format.
+[global_tags]
+  # dc = "us-east-1" # will tag all metrics with dc=us-east-1
+  # rack = "1a"
+  ## Environment variables can be used as tags, and throughout the config file
+  # user = "$USER"
+
+
+# Configuration for telegraf agent
+[agent]
+  ## Default data collection interval for all inputs
+  interval = "15s"
+  ## Rounds collection interval to 'interval'
+  ## ie, if interval="10s" then always collect on :00, :10, :20, etc.
+  round_interval = true
+
+  ## Telegraf will send metrics to outputs in batches of at
+  ## most metric_batch_size metrics.
+  metric_batch_size = 1000
+  ## For failed writes, telegraf will cache metric_buffer_limit metrics for each
+  ## output, and will flush this buffer on a successful write. Oldest metrics
+  ## are dropped first when this buffer fills.
+  metric_buffer_limit = 10000
+
+  ## Collection jitter is used to jitter the collection by a random amount.
+  ## Each plugin will sleep for a random time within jitter before collecting.
+  ## This can be used to avoid many plugins querying things like sysfs at the
+  ## same time, which can have a measurable effect on the system.
+  collection_jitter = "0s"
+
+  ## Default flushing interval for all outputs. You shouldn't set this below
+  ## interval. Maximum flush_interval will be flush_interval + flush_jitter
+  flush_interval = "30s"
+  ## Jitter the flush interval by a random amount. This is primarily to avoid
+  ## large write spikes for users running a large number of telegraf instances.
+  ## ie, a jitter of 5s and interval 10s means flushes will happen every 10-15s
+  flush_jitter = "10s"
+
+  ## Run telegraf in debug mode
+  debug = false
+  ## Run telegraf in quiet mode
+  quiet = true
+  ## Override default hostname, if empty use os.Hostname()
+  hostname = ""
+  ## If set to true, do no set the "host" tag in the telegraf agent.
+  omit_hostname = false
+
+
+###############################################################################
+#                            OUTPUT PLUGINS                                   #
+###############################################################################
+
+# Configuration for influxdb server to send metrics to
+[[outputs.influxdb]]
+  ## The full HTTP or UDP endpoint URL for your InfluxDB instance.
+  ## Multiple urls can be specified as part of the same cluster,
+  ## this means that only ONE of the urls will be written to each interval.
+  # urls = ["udp://localhost:8089"] # UDP endpoint example
+  urls = ["http://serverstats:8086"] # required
+  ## The target database for metrics (telegraf will create it if not exists).
+  database = "ServerStats" # required
+  ## Retention policy to write to.
+  retention_policy = "default"
+  ## Precision of writes, valid values are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+  ## note: using "s" precision greatly improves InfluxDB compression.
+  precision = "s"
+
+  ## Write timeout (for the InfluxDB client), formatted as a string.
+  ## If not provided, will default to 5s. 0s means no timeout (not recommended).
+  timeout = "10s"
+  # username = "telegraf"
+  # password = "metricsmetricsmetricsmetrics"
+  ## Set the user agent for HTTP POSTs (can be useful for log differentiation)
+  # user_agent = "telegraf"
+  ## Set UDP payload size, defaults to InfluxDB UDP Client default (512 bytes)
+  # udp_payload = 512
+
+  ## Optional SSL Config
+  # ssl_ca = "/etc/telegraf/ca.pem"
+  # ssl_cert = "/etc/telegraf/cert.pem"
+  # ssl_key = "/etc/telegraf/key.pem"
+  ## Use SSL but skip chain & host verification
+  # insecure_skip_verify = false
+
+
+
+###############################################################################
+#                            INPUT PLUGINS                                    #
+###############################################################################
+
+# Read metrics about cpu usage
+[[inputs.cpu]]
+  ## Whether to report per-cpu stats or not
+  percpu = false
+  ## Whether to report total system cpu stats or not
+  totalcpu = true
+
+
+# Read metrics about disk usage by mount point
+[[inputs.disk]]
+  ## By default, telegraf gather stats for all mountpoints.
+  ## Setting mountpoints will restrict the stats to the specified mountpoints.
+  mount_points = ["/", "/persist", "/persist2"]
+  drop = ["disk_inodes"]
+
+  ## Ignore some mountpoints by filesystem type. For example (dev)tmpfs (usually
+  ## present on /run, /var/run, /dev/shm or /dev).
+  ignore_fs = ["tmpfs", "devtmpfs"]
+
+
+# Read metrics about disk IO by device
+[[inputs.diskio]]
+  ## By default, telegraf will gather stats for all devices including
+  ## disk partitions.
+  ## Setting devices will restrict the stats to the specified devices.
+  devices = ["md125", "md127", "sda", "sdb", "sdc", "sdd", "sde", "sdf", 
+  "sdg", "sdh", "sdi", "sdj", "sdk", "sdl", "sdm", "sdn", "sdo", "sdp",
+  "sdq", "sdr", "sds", "sdt", "sdu", "sdv","sdw", "sdx", "sdy", "sdz",
+  "sdaa", "sdab", "sdac", "sdad", "sdae", "sdaf", "sdag", "sdah", "sdai",
+  "sdaj", "sdak", "sdal" ]
+  ## Uncomment the following line if you do not need disk serial numbers.
+  skip_serial_number = true
+
+
+# Get kernel statistics from /proc/stat
+[[inputs.kernel]]
+  # no configuration
+
+
+# Read metrics about memory usage
+[[inputs.mem]]
+  # no configuration
+
+
+# Read metrics about network interface usage
+[[inputs.net]]
+  ## By default, telegraf gathers stats from any up interface (excluding loopback)
+  ## Setting interfaces will tell it to gather these explicit interfaces,
+  ## regardless of status.
+  ##
+  interfaces = ["bond0", "macvlan-bond0", "em1", "em2", "p1p1", "p1p2", "p2p1", "p2p2", "p255p1", "p255p2",  "eth0", "eth1", "eth2", "eth3", "eth4", "eth5" ]
+
+
+# Read TCP metrics such as established, time wait and sockets counts.
+[[inputs.netstat]]
+  # no configuration
+
+
+# Get the number of processes and group them by status
+[[inputs.processes]]
+  # no configuration
+
+
+# Read metrics about swap memory usage
+[[inputs.swap]]
+  # no configuration
+
+
+# Read metrics about system load & uptime
+[[inputs.system]]
+  drop = ["uptime_format"]
+
+
+
+###############################################################################
+#                            SERVICE INPUT PLUGINS                            #
+###############################################################################
+
+# Statsd Server
+[[inputs.statsd]]
+  ## Address and port to host UDP listener on
+  service_address = ":8125"
+  ## Delete gauges every interval (default=false)
+  delete_gauges = false
+  ## Delete counters every interval (default=false)
+  delete_counters = false
+  ## Delete sets every interval (default=false)
+  delete_sets = false
+  ## Delete timings & histograms every interval (default=true)
+  delete_timings = true
+  ## Percentiles to calculate for timing & histogram stats
+  percentiles = [90]
+
+  ## separator to use between elements of a statsd metric
+  metric_separator = "."
+
+  ## Parses tags in the datadog statsd format
+  ## http://docs.datadoghq.com/guides/dogstatsd/
+  parse_data_dog_tags = false
+
+  ## Statsd data translation templates, more info can be read here:
+  ## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md#graphite
+  templates = [
+      "swift.account-auditor.* measurement* service=account-auditor,swift=swift",
+      "swift.account-reaper.*.* measurement* service=account-reaper,swift=swift",
+      "swift.account-reaper.* measurement* service=account-reaper,swift=swift",
+      "swift.object-reconstructor.partition.update.count.* measurement.measurement.measurement.measurement.measurement.device service=object-reconstructor,swift=swift",
+      "swift.object-reconstructor.partition.delete.count.* measurement.measurement.measurement.measurement.measurement.device service=object-reconstructor,swift=swift",
+      "swift.object-replicator.partition.update.count.* measurement.measurement.measurement.measurement.measurement.device service=object-replicator,swift=swift",
+      "swift.object-replicator.partition.delete.count.* measurement.measurement.measurement.measurement.measurement.device service=object-replicator,swift=swift",
+      "swift.account-replicator.removes.* measurement.measurement.measurement.device service=account-replicator,swift=swift",
+      "swift.account-replicator.*.*.* measurement* service=account-replicator,swift=swift",
+      "swift.account-replicator.* measurement* service=account-replicator,swift=swift",
+      "swift.account-server.*.*.* measurement.measurement.verb.measurement* service=account-server,swift=swift",
+      "swift.account-server.*.* measurement.measurement.verb.measurement service=account-server,swift=swift",
+      "swift.container-auditor.* measurement* service=container-auditor,swift=swift",
+      "swift.container-replicator.removes.* measurement.measurement.measurement.device service=account-replicator,swift=swift",
+      "swift.container-replicator.* measurement* service=container-replicator,swift=swift",
+      "swift.container-server.*.*.* measurement.measurement.verb.measurement* service=container-server,swift=swift",
+      "swift.container-server.*.* measurement.measurement.verb.measurement service=container-server,swift=swift",
+      "swift.container-sync.*.* measurement* service=container-sync,swift=swift",
+      "swift.container-sync.* measurement* service=container-sync,swift=swift",
+      "swift.container-updater.* measurement* service=container-updater,swift=swift",
+      "swift.object-auditor.* measurement* service=object-auditor,swift=swift",
+      "swift.object-expirer.* measurement* service=object-expirer,swift=swift",
+      "swift.object-reconstructor.*.*.* measurement* service=object-reconstructor,swift=swift",
+      "swift.object-reconstructor.*.* measurement* service=object-reconstructor,swift=swift",
+      "swift.object-replicator.partition.update.timing measurement* service=object-replicator,swift=swift",
+      "swift.object-replicator.partition.delete.timing measurement* service=object-replicator,swift=swift",
+      "swift.object-replicator.*.*.* measurement* service=object-replicator,swift=swift",
+      "swift.object-replicator.*.* measurement* service=object-replicator,swift=swift",
+      "swift.object-server.PUT.timing measurement.measurement.measurement.measurement service=object-server,swift=swift",
+      "swift.object-server.PUT.*.timing measurement.measurement.measurement.device.measurement service=object-server,swift=swift",
+      "swift.object-server.*.*.* measurement.measurement.verb.measurement* service=object-server,swift=swift",
+      "swift.object-server.*.timing measurement.measurement.verb.measurement service=object-server,swift=swift",
+      "swift.object-server.*.* measurement* service=object-server,swift=swift",
+      "swift.object-server.* measurement* service=object-server,swift=swift",
+      "swift.object-updater.* measurement* service=object-updater,swift=swift",
+      "swift.proxy-server.*.*.*.*.* measurement.measurement.type.measurement.status.measurement* service=proxy-server,swift=swift",
+      "swift.proxy-server.*.*.*.* measurement.measurement.type.verb.status.measurement service=proxy-server,swift=swift",
+      "swift.proxy-server.*.* measurement.measurement.type.measurement service=proxy-server,swift=swift",
+      "swift.proxy-server.* measurement* service=proxy-server,swift=swift",
+      "swift.proxy-server.*.*.*.*.*.* measurement.measurement.measurement.measurement.policy.verb.status.measurement service=proxy-server,swift=swift",
+      "swift.proxy-server.*.*.*.*.*.*.* measurement.measurement.measurement.measurement.policy.measurement.status.measurement* service=proxy-server,swift=swift",
+      "swift.tempauth.*.* measurement.measurement.reseller.measurement service=tempauth,swift=swift",
+      "measurement* swiftcatchall=true",
+  ]
+
+  ## Number of UDP messages allowed to queue up, once filled,
+  ## the statsd server will start dropping packets
+  allowed_pending_messages = 10000
+
+  ## Number of timing/histogram values to track per-measurement in the
+  ## calculation of percentiles. Raising this limit increases the accuracy
+  ## of percentiles but also increases the memory usage and cpu time.
+  percentile_limit = 1000

--- a/Arista/arista-package.sh
+++ b/Arista/arista-package.sh
@@ -25,6 +25,7 @@ LINUX_CONFIG_FILES_VER=1.6
 CONFIG_FILES_ITER=13
 REDIS_CONFIG_FILES_VER=1.6
 PERFORCE_CONFIG_FILES_VER=1.6
+SWIFT_CONFIG_FILES_VER=1.0
 QUBIT_SCYLLA_CONFIG_FILES_VER=1.7
 QUBIT_WORKER_CONFIG_FILES_VER=1.6
 QUBIT_SPIN_CONFIG_FILES_VER=1.6
@@ -121,6 +122,11 @@ fpm -s dir -t rpm $CONFIG_FPM_ARGS --iteration "$CONFIG_FILES_ITER" -v "$REDIS_C
 rm -rf $TMP_CONFIG_DIR/etc/telegraf/telegraf.d/*
 cp $CONFIG_FILES_DIR/telegraf-perforce.conf $TMP_CONFIG_DIR/etc/telegraf/telegraf.conf
 fpm -s dir -t rpm $CONFIG_FPM_ARGS --iteration "$CONFIG_FILES_ITER" -v "$PERFORCE_CONFIG_FILES_VER" --description "$DESCRIPTION" -n "telegraf-Perforce" etc lib || cleanup_exit 1
+
+# Swift-Config
+rm -rf $TMP_CONFIG_DIR/etc/telegraf/telegraf.d/*
+cp $CONFIG_FILES_DIR/telegraf-swift.conf $TMP_CONFIG_DIR/etc/telegraf/telegraf.conf
+fpm -s dir -t rpm $CONFIG_FPM_ARGS --iteration "$CONFIG_FILES_ITER" -v "$SWIFT_CONFIG_FILES_VER" --description "$DESCRIPTION" -n "telegraf-Swift" etc lib || cleanup_exit 1
 
 # QUBIT Scylla config
 rm -rf $TMP_CONFIG_DIR/etc/telegraf/telegraf.d/*


### PR DESCRIPTION
Add telegraf config for swift.

telegraf-swift.conf is based off of telegraf-linux.conf with the devices section changed and the 'SERVICE INPUT PLUGINS' section added.