### PR TITLE
update and fix scylla configs

### DIFF
--- a/Arista/ConfigFiles/telegraf-qubit-scylla-dev.conf
+++ b/Arista/ConfigFiles/telegraf-qubit-scylla-dev.conf
@@ -10,7 +10,7 @@
   # urls = ["udp://localhost:8089"] # UDP endpoint example
   urls = ["http://planck:8086"] # required
   ## The target database for metrics (telegraf will create it if not exists).
-  database = "qubit" # required
+  database = "qubit_dev" # required
   ## Retention policy to write to.
   retention_policy = ""
   ## Precision of writes, valid values are "ns", "us" (or "µs"), "ms", "s", "m", "h".

--- a/Arista/arista-package.sh
+++ b/Arista/arista-package.sh
@@ -22,15 +22,16 @@ TMP_CONFIG_DIR=./rpm_config
 CONFIG_FILES_DIR=./ConfigFiles
 
 LINUX_CONFIG_FILES_VER=1.7
-CONFIG_FILES_ITER=13
 REDIS_CONFIG_FILES_VER=1.7
 PERFORCE_CONFIG_FILES_VER=1.7
 SWIFT_CONFIG_FILES_VER=1.1
 QUBIT_SCYLLA_CONFIG_FILES_VER=1.8
+QUBIT_SCYLLA_DEV_CONFIG_FILES_VER=1.1
 QUBIT_WORKER_CONFIG_FILES_VER=1.7
 QUBIT_SPIN_CONFIG_FILES_VER=1.7
 
-BIN_RPM_ITER=1
+CONFIG_FILES_ITER=14
+BIN_RPM_ITER=2
 
 LICENSE=MIT
 URL=github.com/aristanetworks/telegraf
@@ -137,6 +138,12 @@ fpm -s dir -t rpm $CONFIG_FPM_ARGS --iteration "$CONFIG_FILES_ITER" -v "$SWIFT_C
 rm -rf $TMP_CONFIG_DIR/etc/telegraf/telegraf.d/*
 cp $CONFIG_FILES_DIR/telegraf-qubit-scylla.conf $TMP_CONFIG_DIR/etc/telegraf/telegraf.d/
 fpm -s dir -t rpm $CONFIG_FPM_ARGS --iteration "$CONFIG_FILES_ITER" -v "$QUBIT_SCYLLA_CONFIG_FILES_VER" --description "$DESCRIPTION" -n "telegraf-qubit-scylla" etc lib || cleanup_exit 1
+
+# QUBIT Scylla dev config
+rm -rf $TMP_CONFIG_DIR/etc/telegraf/telegraf.d/*
+cp $CONFIG_FILES_DIR/telegraf-qubit-scylla-dev.conf $TMP_CONFIG_DIR/etc/telegraf/telegraf.d/
+fpm -s dir -t rpm $CONFIG_FPM_ARGS --iteration "$CONFIG_FILES_ITER" -v "$QUBIT_SCYLLA_DEV_CONFIG_FILES_VER" --description "$DESCRIPTION" -n "telegraf-qubit-scylla-dev" etc lib || cleanup_exit 1
+
 
 # QUBIT Worker config
 rm -rf $TMP_CONFIG_DIR/etc/telegraf/telegraf.d/*


### PR DESCRIPTION
- added new config for scylla-dev (dev cluster for scylla, stats go to
qubit_dev database)
- fixed the namepass to scylla* since namepass is about measurement
names rather than plugin name
- pushed 1.2.0 tag to the aristanetworks/telegraf repo and republish
the new RPMs to ToolsV2

Testing:
1) tested scylla configs on scylla nodes
2) tested update of telegraf config on us161, watched server metrics in
   grafana and it was fine
