### PR TITLE
Set the smart input plugin interval to 24hrs.

### DIFF
--- a/Arista/ConfigFiles/telegraf-default.conf
+++ b/Arista/ConfigFiles/telegraf-default.conf
@@ -137,6 +137,7 @@
 [[inputs.smart]]
   ## Optionally specify the path to the smartctl executable
   path = "/usr/sbin/smartctl"
+  interval = "24h"
   #
   ## On most platforms smartctl requires root access.
   ## Setting 'use_sudo' to true will make use of sudo to run smartctl.


### PR DESCRIPTION
Set the interval to 24hrs, we don't need smart data as often as the default interval. Testing by running telegraf --config <> -test.
