### PR TITLE
wait for hostname to be available before starting

### DIFF
--- a/Arista/ConfigFiles/telegraf-networkd.service
+++ b/Arista/ConfigFiles/telegraf-networkd.service
@@ -5,6 +5,7 @@ After=network-online.target
 
 [Service]
 EnvironmentFile=-/etc/default/telegraf
+ExecStartPre=/bin/sh -c 'while [ "`hostname`" == "localhost.localdomain" ]; do sleep 1; /bin/echo "Waiting for hostname to be setup" >&1; done '
 ExecStart=/usr/bin/telegraf -config /etc/telegraf/telegraf.conf -config-directory /etc/telegraf/telegraf.d $TELEGRAF_OPTS
 KillMode=process
 # Journald restart in systemd < v219 causes SIGPIPE which is considered clean exit


### PR DESCRIPTION
When telegraf starts with localhost.localdomain as the hostname,
it sticks with that hostname even after the hostname changes later on.
This happens mostly during server startup. Posting points with
localhost.localdomain messes up lot of monitoring aspects.

On systemd-networkd based systems, the following link
explains how to make a systemd service start after the interface
is fully setup. (refer
https://www.freedesktop.org/wiki/Software/systemd/NetworkTarget/)
But using repeated experiments it was confirmed that those steps
do not work reliably. There are reports from other users about
network-online.target not behaving as expected. See
https://community.getchannels.com/t/wait-for-networking-on-reboot-ubuntu-network-online-target/936

So we are using a simple and yet gauranteed workaround suggested in
https://github.com/coreos/bugs/issues/1966

Testing:
Repeated testing confirmed that this method is completely reliable.

This issue is avoided in dhclient based systems since we rely on
dhclient helper to delay start telegraf. However, we could use the
same change on dhclient based systems too if needed.

