### PR TITLE
fix worker node telegraf config

### DIFF
--- a/Arista/ConfigFiles/telegraf-qubit-worker.conf
+++ b/Arista/ConfigFiles/telegraf-qubit-worker.conf
@@ -10,26 +10,6 @@
   # urls = ["udp://localhost:8089"] # UDP endpoint example
   urls = ["http://planck:8086"] # required
   ## The target database for metrics (telegraf will create it if not exists).
-  database = "qubit" # required
-  ## Retention policy to write to.
-  retention_policy = ""
-  ## Precision of writes, valid values are "ns", "us" (or "µs"), "ms", "s", "m", "h".
-  ## note: using "s" precision greatly improves InfluxDB compression.
-  precision = "s"
-
-  ## Write timeout (for the InfluxDB client), formatted as a string.
-  ## If not provided, will default to 5s. 0s means no timeout (not recommended).
-  timeout = "10s"
-   namepass = 
-
-# Configuration for influxdb server to send metrics to
-[[outputs.influxdb]]
-  ## The full HTTP or UDP endpoint URL for your InfluxDB instance.
-  ## Multiple urls can be specified as part of the same cluster,
-  ## this means that only ONE of the urls will be written to each interval.
-  # urls = ["udp://localhost:8089"] # UDP endpoint example
-  urls = ["http://planck:8086"] # required
-  ## The target database for metrics (telegraf will create it if not exists).
   database = "ServerStats" # required
   ## Retention policy to write to.
   retention_policy = ""


### PR DESCRIPTION
Telegraf version complains about bad TOML configuration.

`Oct 08 10:05:05 XXXX telegraf[27531]: 2018/10/08 10:05:05 E! Error parsing /etc/telegraf/telegraf.d/telegraf-qubit-worker.conf, toml: line 23: parse error`

Removed the unwanted section. We don't have any metrics on this kind of node
destined for qubit database.

Testing: tested manually on a worker node