### PR TITLE
Keep perforce data forever

### DIFF
--- a/Arista/ConfigFiles/telegraf-perforce.conf
+++ b/Arista/ConfigFiles/telegraf-perforce.conf
@@ -12,7 +12,7 @@
   ## The target database for metrics (telegraf will create it if not exists).
   database = "ServerStats" # required
   ## Retention policy to write to.
-  retention_policy = ""
+  retention_policy = "dangerous"
   ## Precision of writes, valid values are "ns", "us" (or "µs"), "ms", "s", "m", "h".
   ## note: using "s" precision greatly improves InfluxDB compression.
   precision = "s"


### PR DESCRIPTION
Keep perforce data forever. This was requested by Thomas. I have also create a RP on influx for this. Tested that telegraf writes to "dangerous" rp on p4-.

As for the naming -- I want to discourage keeping data forever.