### PR TITLE
Additional session counters for varnish.

### DIFF
--- a/Arista/ConfigFiles/telegraf-varnish.conf
+++ b/Arista/ConfigFiles/telegraf-varnish.conf
@@ -38,7 +38,7 @@
   ## Setting stats will override the defaults shown below.
   ## Glob matching can be used, ie, stats = ["MAIN.*"]
   ## stats may also be set to ["*"], which will collect all stats
-  stats = ["MAIN.cache_hit", "MAIN.cache_miss", "MAIN.uptime"]
+  stats = ["MAIN.cache_hit", "MAIN.cache_miss", "MAIN.uptime", "MAIN.sess_conn", "MAIN.sess_drop", "MAIN.sess_fail"]
 
   ## Optional name for the varnish instance (or working directory) to query
   ## Usually appened after -n in varnish cli


### PR DESCRIPTION
Adding a few session counters to be monitored on varnish.
Tested using the command - "telegraf --test --config telegraf-varnish.conf"
