### PR TITLE
telegraf: Adding network bond stats

### DIFF
--- a/Arista/ConfigFiles/telegraf-default.conf
+++ b/Arista/ConfigFiles/telegraf-default.conf
@@ -187,3 +187,14 @@
   # ssl_key = "/etc/telegraf/key.pem"
   ## Use SSL but skip chain & host verification
   # insecure_skip_verify = false
+
+[[inputs.bond]]
+  ## Sets 'proc' directory path
+  ## If not specified, then default is /proc
+  # host_proc = "/proc"
+
+  ## By default, telegraf gather stats for all bond interfaces
+  ## Setting interfaces will restrict the stats to the specified
+  ## bond interfaces.
+  # bond_interfaces = ["bond0"]
+

--- a/Arista/ConfigFiles/telegraf-linux.conf
+++ b/Arista/ConfigFiles/telegraf-linux.conf
@@ -21,4 +21,4 @@
   ## If not provided, will default to 5s. 0s means no timeout (not recommended).
   timeout = "10s"
 
-  namepass = ["cpu", "disk", "diskio", "kernel", "mem", "net", "netstat", "processes", "swap", "system", "smart*","apache"]
+  namepass = ["cpu", "disk", "diskio", "kernel", "mem", "net", "netstat", "processes", "swap", "system", "smart*", "apache", "bond*" ]


### PR DESCRIPTION
This will collect stats for each of the bond(lag) interface
https://github.com/influxdata/telegraf/tree/master/plugins/inputs/bond

Ex:
* Plugin: inputs.bond, Collection 1
> bond,bond=bond0,host=us180.sjc.aristanetworks.com status=1i 1558393133000000000
> bond_slave,interface=em1,host=us180.sjc.aristanetworks.com,bond=bond0 status=1i,failures=0i 1558393133000000000
> bond_slave,bond=bond0,interface=em2,host=us180.sjc.aristanetworks.com status=1i,failures=0i 1558393133000000000

