### PR TITLE
Monitor additional network interfaces "p2049p1" and "p2049p2"

### DIFF
--- a/Arista/ConfigFiles/telegraf-default.conf
+++ b/Arista/ConfigFiles/telegraf-default.conf
@@ -111,7 +111,7 @@
   ## Setting interfaces will tell it to gather these explicit interfaces,
   ## regardless of status.
   ##
-  interfaces = ["bond0", "macvlan-bond0", "em1", "em2", "p1p1", "p1p2", "p2p1", "p2p2", "p255p1", "p255p2",  "eth0", "eth1", "eth2", "eth3", "eth4", "eth5" ]
+  interfaces = [ "bond*", "em*", "eth*", "macvlan*", "p*" ]
 
 
 # Read TCP metrics such as established, time wait and sockets counts.


### PR DESCRIPTION
List was getting too big so introduced wild cards.

Verified on us180:
Before:
```
> select bytes_recv,interface from net where host =~ /us180/ and time > now() - 15s
name: net
time                 bytes_recv    interface
----                 ----------    ---------
2019-05-21T16:12:00Z 8681482134684 bond0
2019-05-21T16:12:00Z 8067198619752 macvlan-bond0
2019-05-21T16:12:00Z 4259672795779 em2
2019-05-21T16:12:00Z 4421809338905 em1
```
After editing telegraf.conf
```
> select bytes_recv,interface from net where host =~ /us180/ and time > now() - 15s
name: net
time                 bytes_recv    interface
----                 ----------    ---------
2019-05-21T16:13:30Z 8681670819982 bond0
2019-05-21T16:13:30Z 8067379249577 macvlan-bond0
2019-05-21T16:13:30Z 4259675650446 em2
2019-05-21T16:13:30Z 4421995169536 em1
```