### PR TITLE
Add telegraf config to dump ninja stats

### DIFF
--- a/Arista/ConfigFiles/telegraf-ninja.conf
+++ b/Arista/ConfigFiles/telegraf-ninja.conf
@@ -1,0 +1,30 @@
+# Configuration for influxdb server to send metrics to
+[[outputs.influxdb]]
+  ## The full HTTP or UDP endpoint URL for your InfluxDB instance.
+  ## Multiple urls can be specified as part of the same cluster,
+  ## this means that only ONE of the urls will be written to each interval.
+  # urls = ["udp://localhost:8089"] # UDP endpoint example
+  urls = ["http://planck:8086"] # required
+  ## The target database for metrics (telegraf will create it if not exists).
+  database = "qubit" # required
+  ## Retention policy to write to.
+  retention_policy = ""
+  ## Precision of writes, valid values are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+  ## note: using "s" precision greatly improves InfluxDB compression.
+  precision = "s"
+
+  ## Write timeout (for the InfluxDB client), formatted as a string.
+  ## If not provided, will default to 5s. 0s means no timeout (not recommended).
+  timeout = "10s"
+
+  namepass = ["exec", "ninja*"]
+
+[[inputs.exec]]
+  commands = [
+    '''
+    env NINJA_STATS_DIRECTORY=/host-share/telegraf/ninja/ NINJA_STATS_MAX_FILES_TO_INGEST=20 ninjaDump
+    '''
+  ]
+  timeout = "10s"
+  interval = "5m"
+  data_format = "influx"

--- a/Arista/arista-package.sh
+++ b/Arista/arista-package.sh
@@ -111,6 +111,7 @@ cp $CONFIG_FILES_DIR/telegraf-networkd.service $TMP_CONFIG_DIR/lib/systemd/syste
 cp $CONFIG_FILES_DIR/telegraf-networkd.service $TMP_CONFIG_DIR/lib/systemd/system/telegraf.service
 mkdir -p $TMP_CONFIG_DIR/etc/telegraf
 mkdir -p $TMP_CONFIG_DIR/etc/telegraf/telegraf.d
+mkdir -p $TMP_CONFIG_DIR/usr/bin
 
 # Linux-Config
 rm -f $TMP_CONFIG_DIR/etc/telegraf/telegraf.d/*
@@ -162,6 +163,12 @@ fpm -s dir -t rpm $CONFIG_FPM_ARGS --description "$DESCRIPTION" -n "telegraf-qub
 rm -rf $TMP_CONFIG_DIR/etc/telegraf/telegraf.d/*
 cp $CONFIG_FILES_DIR/telegraf-varnish.conf $TMP_CONFIG_DIR/etc/telegraf/telegraf.d/
 fpm -s dir -t rpm $CONFIG_FPM_ARGS --description "$DESCRIPTION" -n "telegraf-varnish" etc lib || cleanup_exit 1
+
+# Ninja config
+rm -rf $TMP_CONFIG_DIR/etc/telegraf/telegraf.d/*
+cp $CONFIG_FILES_DIR/telegraf-ninja.conf $TMP_CONFIG_DIR/etc/telegraf/telegraf.d/
+cp ./ninjaDump $TMP_CONFIG_DIR/usr/bin/
+fpm -s dir -t rpm -d python $CONFIG_FPM_ARGS --description "$DESCRIPTION" -n "telegraf-ninja" etc lib usr || cleanup_exit 1
 
 mv ./*.rpm RPMS
 

--- a/Arista/ninjaDump
+++ b/Arista/ninjaDump
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+
+import sys
+import shutil
+import os
+
+from os import listdir
+from os.path import isfile, join
+
+ninjaStatsDirectory=os.environ.get('NINJA_STATS_DIRECTORY')
+filesToIngest = os.environ.get('NINJA_STATS_MAX_FILES_TO_INGEST')
+
+if not ninjaStatsDirectory:
+   print 'NINJA_STATS_DIRECTORY not configured'
+   sys.exit(1)
+
+# A safety valve to stop stats collection
+if isfile(join(ninjaStatsDirectory, "DISABLED")):
+   print 'Ninja stats collection disabled'
+   sys.exit(0)
+
+if not filesToIngest:
+   filesToIngest = '10'
+filesToIngest = int( filesToIngest )
+
+files = [ f for f in listdir( ninjaStatsDirectory ) if isfile(
+         join( ninjaStatsDirectory, f ) ) ]
+
+files = files[:filesToIngest]
+
+for f in sorted( files ):
+   f = join( ninjaStatsDirectory, f )
+   with open( f, "r" ) as fd:
+      try:
+         shutil.copyfileobj( fd, sys.stdout )
+      except e:
+         raise e
+   os.remove(f)


### PR DESCRIPTION
* Collect ninja stats from NINJA_STATS_DIRECTORY which are already in
  line protocol format.
* Add ninjaDump to dump the stats on stdout and cleanup the files from
  NINJA_STATS_DIRECTORY.
* Package the ninja configuration and ninjaDump in an rpm.
